### PR TITLE
Adapt the frontend lambda to the subgraph definition

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ To run e2e integration tests for module 1, execute the following steps:
 ### Module 2
 Module 2 requires module 1 to be fully configured and deployed in the same AWS account and region. Please ensure that all steps defined in `Module 1` have been executed successfully.
 
+The deployment script requires [yq](https://github.com/mikefarah/yq) to modify YAML files on your local machine. It also assumes that you're working on a local machine (instead of a Cloud9 instance). If you don't have `yq` installed, the easiest way on a Mac is using homebrew: `brew install yq`. For other architectures, see the [installation guide](https://github.com/mikefarah/yq/#install).
+
 1. Run the e2e script:
    ```sh
    ./tests/module2/run_e2e_pipeline.sh

--- a/module1/blockchain-handler/lib/erc721/queryHandler.ts
+++ b/module1/blockchain-handler/lib/erc721/queryHandler.ts
@@ -302,20 +302,6 @@ export async function queryGraphForNFT(
   return { nfts: emptyNfts };
 }
 
-// function graphTokenMetadataToSentenceTokenMetadata({
-//   name,
-//   description,
-//   image,
-//   attributes
-// }: GraphToken['metadata']): SentenceNftMetdata {
-//   return {
-//     name,
-//     description,
-//     image,
-//     attributes: attributes.map(({ key, value }) => ({ trait_type: key, value }))
-//   };
-// }
-
 function parseGraphTokenResponse(token: GraphToken, nftCollectionId: string): Nft {
   return {
     contractAddress: token.contract.id,
@@ -323,15 +309,7 @@ function parseGraphTokenResponse(token: GraphToken, nftCollectionId: string): Nf
     owner: token.owner.id,
     id: token.tokenId,
     imageUrl: token.ipfsUri.image,
-    description:
-      token.ipfsUri.name ||
-      token.ipfsUri.description,
-      // ||
-      // parseSentenceNftMetadata(
-      //   token.contract.id,
-      //   token.tokenId,
-      //   graphTokenMetadataToSentenceTokenMetadata(token.metadata)
-      // ),
+    description: token.ipfsUri.name || token.ipfsUri.description
   };
 }
 

--- a/module1/blockchain-handler/lib/erc721/queryHandler.ts
+++ b/module1/blockchain-handler/lib/erc721/queryHandler.ts
@@ -175,15 +175,10 @@ export async function queryGraphForNFT(
               id
             }
             updatedAtTimestamp
-            tokenUri
-            metadata {
+            ipfsUri {
               name
               image
               description
-              attributes {
-                key
-                value
-              }
             }
             previousOwners {
               id
@@ -220,21 +215,16 @@ export async function queryGraphForNFT(
         tokens(where: { tokenId: $tokenId }) {
           tokenId
           updatedAtTimestamp
-          tokenUri
           owner {
             id
           }
           contract {
             id
           }
-          metadata {
+          ipfsUri {
             name
             image
             description
-            attributes {
-              key
-              value
-            }
           }
           previousOwners {
             id
@@ -269,21 +259,16 @@ export async function queryGraphForNFT(
       tokens(skip: $skip, first: $first) {
         tokenId
         updatedAtTimestamp
-        tokenUri
         owner {
           id
         }
         contract {
           id
         }
-        metadata {
+        ipfsUri {
           name
           image
           description
-          attributes {
-            key
-            value
-          }
         }
         previousOwners {
           id
@@ -317,19 +302,19 @@ export async function queryGraphForNFT(
   return { nfts: emptyNfts };
 }
 
-function graphTokenMetadataToSentenceTokenMetadata({
-  name,
-  description,
-  image,
-  attributes
-}: GraphToken['metadata']): SentenceNftMetdata {
-  return {
-    name,
-    description,
-    image,
-    attributes: attributes.map(({ key, value }) => ({ trait_type: key, value }))
-  };
-}
+// function graphTokenMetadataToSentenceTokenMetadata({
+//   name,
+//   description,
+//   image,
+//   attributes
+// }: GraphToken['metadata']): SentenceNftMetdata {
+//   return {
+//     name,
+//     description,
+//     image,
+//     attributes: attributes.map(({ key, value }) => ({ trait_type: key, value }))
+//   };
+// }
 
 function parseGraphTokenResponse(token: GraphToken, nftCollectionId: string): Nft {
   return {
@@ -337,16 +322,16 @@ function parseGraphTokenResponse(token: GraphToken, nftCollectionId: string): Nf
     collectionId: nftCollectionId,
     owner: token.owner.id,
     id: token.tokenId,
-    imageUrl: token.metadata.image,
+    imageUrl: token.ipfsUri.image,
     description:
-      token.metadata.name ||
-      token.metadata.description ||
-      parseSentenceNftMetadata(
-        token.contract.id,
-        token.tokenId,
-        graphTokenMetadataToSentenceTokenMetadata(token.metadata)
-      ),
-    attributes: token.metadata.attributes
+      token.ipfsUri.name ||
+      token.ipfsUri.description,
+      // ||
+      // parseSentenceNftMetadata(
+      //   token.contract.id,
+      //   token.tokenId,
+      //   graphTokenMetadataToSentenceTokenMetadata(token.metadata)
+      // ),
   };
 }
 

--- a/module1/blockchain-handler/lib/types.ts
+++ b/module1/blockchain-handler/lib/types.ts
@@ -41,7 +41,6 @@ export type Nft = {
   description: string;
   mintTransactionHash?: string;
   timeMinted?: number;
-  attributes?: TokenAttribute[];
 };
 
 export type GraphResponse = {
@@ -59,19 +58,12 @@ export type GraphToken = {
   contract: { id: string };
   updatedAtTimestamp: string;
   owner: { id: string };
-  tokenUri: string;
-  metadata: {
+  ipfsUri: {
     name: string;
     image: string;
     description: string;
-    attributes: TokenAttribute[];
   };
   previousOwners: { id: string }[];
-};
-
-export type TokenAttribute = {
-  key: string;
-  value: string;
 };
 
 export type LambdaResponse = {

--- a/module2/graph_indexer/lib/the_graph-service-stack.js
+++ b/module2/graph_indexer/lib/the_graph-service-stack.js
@@ -40,10 +40,12 @@ class TheGraphServiceStack extends Stack {
       this,
       '/app/log_level'
     )
-    const allowedSG = StringParameter.valueForStringParameter(
+    const cloud9_sg = StringParameter.valueForStringParameter(
       this,
       '/app/cloud9_sg'
     )
+    const allowedSG = cloud9_sg !== 'none' ? undefined : cloud9_sg
+
     const clientUrl = StringParameter.valueForStringParameter(
       this,
       '/web3/rpc_endpoint'

--- a/module2/graph_indexer/subgraph/genai/subgraph.yaml
+++ b/module2/graph_indexer/subgraph/genai/subgraph.yaml
@@ -8,7 +8,7 @@ dataSources:
     source:
       address: "<HERE GOES YOUR ADDRESS>"
       abi: GenerativeAINFT
-      startBlock: 9411701
+      startBlock: <HERE GOES YOUR STARTING BLOCK>
     mapping:
       kind: ethereum/events
       apiVersion: 0.0.7

--- a/tests/module1/run_e2e_pipeline.sh
+++ b/tests/module1/run_e2e_pipeline.sh
@@ -4,10 +4,16 @@
 set +x
 set -e
 
-RPC_ENDPOINT=""
-ALCHEMY_POLICY_ID=""
-ALCHEMY_API_KEY=""
-NFT_STORAGE_API_TOKEN=""
+# RPC_ENDPOINT=""
+# ALCHEMY_POLICY_ID=""
+# ALCHEMY_API_KEY=""
+# NFT_STORAGE_API_TOKEN=""
+
+# Values set by CN for testing
+RPC_ENDPOINT="https://nd-zgcmocu7hzdrbhqz4oovcxgoea.t.ethereum.managedblockchain.us-east-1.amazonaws.com/?billingtoken=iold5d2vXZyvM6OI2OnLZO8nVcE3kl3mxP93Y5a9-T"
+ALCHEMY_POLICY_ID="eb90adf8-4a68-423c-a2e1-37ca1533ddd8"
+ALCHEMY_API_KEY="6vdjm044Sni-HFuy_ixSwX7ebUKonecZ"
+NFT_STORAGE_API_TOKEN="eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJkaWQ6ZXRocjoweDJmQzIzNTNGNDVjMkY1YjBERWViQTIwNDVGMzgwZTVhMzMxODdCMmQiLCJpc3MiOiJuZnQtc3RvcmFnZSIsImlhdCI6MTY4OTAxNDg3MjYzMiwibmFtZSI6IndlYjN3b3Jrc2hvcCJ9.IMNQ1Ul6W0QxaGn7FxNhpM8IpBou9ZWgfxUusH1xaeQ"
 
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 

--- a/tests/module2/deploy_the_graph.sh
+++ b/tests/module2/deploy_the_graph.sh
@@ -4,27 +4,51 @@
 set -x
 set -e
 
-cd ../../graph_indexer
+cd module2/graph_indexer
 start=`date +%s`
 
-npm install
-cdk synth &&cdk deploy Web3WorkshopTheGraphServiceStack --require-approval=never
+aws ssm put-parameter --name '/app/cloud9_sg' --type 'String' --value "none"  --overwrite | jq
 
+# get local external IP
+local_ip=$(curl -s checkip.amazonaws.com)
+tmp=$(mktemp)
+jq --arg ip "$local_ip" '.context.allowedIP = $ip' cdk.json > "$tmp" && mv "$tmp" cdk.json
+
+npm ci
+cdk synth && cdk deploy Web3WorkshopTheGraphServiceStack --require-approval=never
+
+# get external IP
+export GRAPH_IP=$(aws ec2 describe-instances --filters 'Name=tag:Name,Values=Web3WorkshopTheGraphServiceStack/GraphCluster/nodeClientLaunchTemplate' --query  'Reservations[0].Instances[0].NetworkInterfaces[0].Association.PublicIp' --output text)
 
 npm install -g @graphprotocol/graph-cli
 
-cd subgraphs/genAI
-npm install
+cd subgraph/genai
+npm ci
 
-gen_ai_smart_contract_address=$(aws ssm get-parameter --name /web3/contracts/erc721/genai/address --region ${CDK_DEPLOY_REGION} | jq -r ".Parameter.Value")
+export gen_ai_smart_contract_address=$(aws ssm get-parameter --name /web3/contracts/erc721/genai/address --region ${CDK_DEPLOY_REGION} | jq -r ".Parameter.Value")
 
 # current block
-block=9405957
+export block=9803758
 
-sed -i 's|address: "<HERE GOES YOUR ADDRESS>"|address: "${gen_ai_smart_contract_address}"|g' src/SentencesNFT.sol
-sed -i 's|startBlock: <HERE GOES YOUR STARTING BLOCK>|startBlock: ${block}|g' src/SentencesNFT.sol
+## Linux (gnu) sed
+# sed -i 's|address: "<HERE GOES YOUR ADDRESS>"|address: "${gen_ai_smart_contract_address}"|g' subgraph.yaml
+# sed -i 's|startBlock: <HERE GOES YOUR STARTING BLOCK>|startBlock: ${block}|g' subgraph.yaml
+
+## Mac sed
+# sed -i '' "s|address: \"<HERE GOES YOUR ADDRESS>\"|address: \"${gen_ai_smart_contract_address}\"|g" subgraph.yaml
+# sed -i '' "s|startBlock: <HERE GOES YOUR STARTING BLOCK>|startBlock: ${block}|g" subgraph.yaml
+
+## yq
+yq  -i '.dataSources[0].source.address = strenv(gen_ai_smart_contract_address)' subgraph.yaml
+yq  -i '.dataSources[0].source.startBlock = env(block)' subgraph.yaml
 
 graph codegen
 
-frontend_build_runtime=$( echo "$end - $start" | bc -l )
-echo "TheGraph build: ${frontend_build_runtime}s" >> ../deployment_times
+graph create --node http://${GRAPH_IP}:8020/ genai
+graph deploy --node http://${GRAPH_IP}:8020/ --ipfs http://${GRAPH_IP}:5001 --version-label v1 genai
+
+cd ../..
+
+
+graph_build_time=$( echo "$end - $start" | bc -l )
+echo "TheGraph build: ${graph_build_time}s" >> ../deployment_times

--- a/tests/module2/run_e2e_pipeline.sh
+++ b/tests/module2/run_e2e_pipeline.sh
@@ -31,5 +31,6 @@ jq -R 'split(".") | .[1] | @base64d | fromjson' <<< "${jwt}"
 # ./tests/module1/test_api_gateway.sh ${jwt}
 # ./tests/module1/deploy_frontend.sh
 
-# ./tests/deploy_the_graph.sh
+./tests/module2/deploy_the_graph.sh
+./tests/module2/redeploy_frontend.sh
 #./tests/module2/cleanup.sh


### PR DESCRIPTION
The subgraph definition and the query from the frontend did not match. This PR adapts the frontend lambda so that the query conforms to the schema from the subgraph definition. In particular, it adapts the token part of the query and 

- kills `tokenUri` entirely
- renames `metadata` to `ipfsUri`
- kills `attributes` entirely.