### PR TITLE
Fix retrieving cloud9 security group id for security group rule creat…

### DIFF
--- a/module2/graph_indexer/lib/the_graph-service-stack.js
+++ b/module2/graph_indexer/lib/the_graph-service-stack.js
@@ -40,11 +40,19 @@ class TheGraphServiceStack extends Stack {
       this,
       '/app/log_level'
     )
-    const cloud9_sg = StringParameter.valueForStringParameter(
-      this,
-      '/app/cloud9_sg'
-    )
-    const allowedSG = cloud9_sg !== 'none' ? undefined : cloud9_sg
+    const tryGetAllowedSG = () => {
+      try {
+        const parameterName = '/app/cloud9_sg'
+        // we are using valueFromLookup instead of valueForStringParameter because
+        // valueForStringParameter doesn't retrieve the value until deployment. We
+        // need it at synth time already, because depending on it we are creating conditional resources.
+        const cloud9_sg = StringParameter.valueFromLookup(this, parameterName)
+        return cloud9_sg.startsWith('dummy-value-for') || cloud9_sg === 'none' ? undefined : cloud9_sg
+      } catch (e) {
+        return undefined
+      }
+    }
+    const allowedSG = tryGetAllowedSG()
 
     const clientUrl = StringParameter.valueForStringParameter(
       this,


### PR DESCRIPTION
*Issue #, if available:* n/a

*Description of changes:* 
Cloud9 instance cannot connect to Graph Cluster to deploy subgraph because security group never gets configured. 
Correctly setup if statement to not add security group if SSM Parameter stores `none` value. Use `valueFromLookup` instead of `valueForStringParameter`. `valueForStringParameter` returns a cdk token reference so the if statement is pointless because the SSM parameter is only resolved at deploy time.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
