### PR TITLE
Change contract artifact to use S3 Managed encryption

### DIFF
--- a/module1/blockchain-handler/lib/blockchain-transaction-lambda-cdk-stack.ts
+++ b/module1/blockchain-handler/lib/blockchain-transaction-lambda-cdk-stack.ts
@@ -71,13 +71,6 @@ export class BlockchainTransactionLambdaCdkStack extends cdk.Stack {
       })
     );
 
-    lambdaRole.addToPolicy(
-      new PolicyStatement({
-        actions: ['kms:Decrypt'],
-        resources: ['*']
-      })
-    );
-
     // Give this Lambda permission to read SSM params at runtime
 
     const parameterStoreWeb3ARN = `arn:aws:ssm:${this.region}:${this.account}:parameter/web3/*`;

--- a/module1/nft-pipeline/bin/ci.ts
+++ b/module1/nft-pipeline/bin/ci.ts
@@ -19,4 +19,5 @@ NagSuppressions.addStackSuppressions(pipelineStack, [
     { id: 'AwsSolutions-IAM5', reason: 'Permission to read CF stack is restrictive enough' },
     { id: 'AwsSolutions-S1', reason: 'Access logs not required on the bucket' },
     { id: 'AwsSolutions-KMS5', reason: 'KMS key rotation not required' },
+    { id: 'AwsSolutions-CB4', reason: 'Uses S3 key for encryption' },
 ], true);

--- a/module1/nft-pipeline/lib/ci-stack.ts
+++ b/module1/nft-pipeline/lib/ci-stack.ts
@@ -19,7 +19,7 @@ export class CiStack extends cdk.Stack {
     const solidityS3Bucket = new s3.Bucket(this, 'SolidityS3Bucket', {
       removalPolicy: RemovalPolicy.DESTROY,
       enforceSSL: true,
-      encryption: s3.BucketEncryption.KMS,
+      encryption: s3.BucketEncryption.S3_MANAGED,
       blockPublicAccess: s3.BlockPublicAccess.BLOCK_ALL,
     });
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Change the S3 bucket that stores the smart contract artifacts to use S3 Managed encryption keys, so we don't have residual KMS keys after cleanup.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
